### PR TITLE
Fixed issue with tracking an inherited model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
+- Fix history detail view on django-admin for abstract models (gh-308)
+- Fix issue with tracking an inherited model (abstract class) (gh-269)
 
 1.9.0 (2017-06-11)
 ------------------

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -29,6 +29,7 @@ def register(
     records.manager_name = manager_name
     records.table_name = table_name
     records.module = app and ("%s.models" % app) or model.__module__
+    records.called_by_register = True
     records.add_extra_methods(model)
     records.finalize(model)
     models.registered_models[model._meta.db_table] = model

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -42,6 +42,7 @@ class HistoricalRecords(object):
         self.user_related_name = user_related_name
         self.table_name = table_name
         self.inherit = inherit
+        self.called_by_register = False
         if excluded_fields is None:
             excluded_fields = []
         self.excluded_fields = excluded_fields
@@ -115,7 +116,7 @@ class HistoricalRecords(object):
         app_module = '%s.models' % model._meta.app_label
         if model.__module__ != self.module:
             # registered under different app
-            attrs['__module__'] = self.module
+            attrs['__module__'] = self.module if self.called_by_register else app_module
         elif app_module != self.module:
             try:
                 # Abuse an internal API because the app registry is loading.
@@ -131,6 +132,8 @@ class HistoricalRecords(object):
         attrs.update(self.get_extra_fields(model, fields))
         # type in python2 wants str as a first argument
         attrs.update(Meta=type(str('Meta'), (), self.get_meta_options(model)))
+        if not self.called_by_register:
+            attrs['Meta'].app_label = model._meta.app_label
         if self.table_name is not None:
             attrs['Meta'].db_table = self.table_name
         name = 'Historical%s' % model._meta.object_name

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -10,19 +10,15 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models.fields.proxy import OrderWrt
 from django.test import TestCase
+
 from simple_history.models import HistoricalRecords, convert_auto_field
 from simple_history.utils import update_change_reason
-
 from ..external.models import ExternalModel2, ExternalModel4
-from ..models import (AbstractBase, AdminProfile, Book, Bookcase, Choice, City,
-                      ConcreteAttr, ConcreteUtil, Contact, ContactRegister,
-                      Country, Document, Employee, ExternalModel1,
-                      ExternalModel3, FileModel, HistoricalChoice,
-                      HistoricalCustomFKError, HistoricalPoll, HistoricalState,
-                      Library, MultiOneToOne, Person, Poll, PollInfo,
-                      PollWithExcludeFields, Province, Restaurant, SelfFK,
-                      Series, SeriesWork, State, Temperature,
-                      UnicodeVerboseName, WaterLevel)
+from ..models import AbstractBase, AdminProfile, Book, Bookcase, Choice, City, ConcreteAttr, ConcreteExternal, \
+    ConcreteUtil, Contact, ContactRegister, Country, Document, Employee, ExternalModel1, ExternalModel3, FileModel, \
+    HistoricalChoice, HistoricalCustomFKError, HistoricalPoll, HistoricalState, Library, MultiOneToOne, Person, Poll, \
+    PollInfo, PollWithExcludeFields, Province, Restaurant, SelfFK, Series, SeriesWork, State, Temperature, \
+    UnicodeVerboseName, WaterLevel
 
 try:
     from django.apps import apps
@@ -422,6 +418,13 @@ class AppLabelTest(TestCase):
                          ExternalModel4)
         self.assertEqual(get_model('tests', 'HistoricalExternalModel4'),
                          ExternalModel4.histories.model)
+
+        # Test that historical model is defined within app of concrete
+        # model rather than abstract base model
+        self.assertEqual(get_model('tests', 'ConcreteExternal'),
+                         ConcreteExternal)
+        self.assertEqual(get_model('tests', 'HistoricalConcreteExternal'),
+                         ConcreteExternal.history.model)
 
 
 class HistoryManagerTest(TestCase):


### PR DESCRIPTION
If an abstract model is defined in a different app than the concrete model, the historical table is defined in the same app as the concrete model